### PR TITLE
TooManySecrets

### DIFF
--- a/13_Secrets/pubsub-secret.yaml
+++ b/13_Secrets/pubsub-secret.yaml
@@ -23,3 +23,4 @@ spec:
           mountPath: /var/secrets/google
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/google/key.json


### PR DESCRIPTION
Fix for Yaml that did not have the GOOGLE_APPLICATION_CREDENTIALS value set. Oops.