### PR TITLE
Correct RoleBinding

### DIFF
--- a/15_RBAC/pod-reader-role.yaml
+++ b/15_RBAC/pod-reader-role.yaml
@@ -6,4 +6,4 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["create","get", "list", "watch"]

--- a/15_RBAC/username2-editor-binding.yaml
+++ b/15_RBAC/username2-editor-binding.yaml
@@ -8,6 +8,6 @@ subjects:
   name: [USERNAME_2_EMAIL]
   apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: ClusterRole
-  name: editor
+  kind: Role
+  name: edit
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixed RBAC example using a simple Role that grants create rights.
Previous example referred to an editor ClusterRole that doesn't exist and was confused. Thsi example now uses and demonstrates jsut the Role permission.