### PR TITLE
Fixed RBAC role

### DIFF
--- a/15_RBAC/username2-editor-binding.yaml
+++ b/15_RBAC/username2-editor-binding.yaml
@@ -9,5 +9,5 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role
-  name: edit
+  name: pod-reader
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixing edit role name in previous version should have been pod-reader for the RoleBinding.