### PR TITLE
SQl-Proxy secrets bug

### DIFF
--- a/18_Cloud_SQL/sql-proxy.yaml
+++ b/18_Cloud_SQL/sql-proxy.yaml
@@ -44,7 +44,7 @@ spec:
           image: gcr.io/cloudsql-docker/gce-proxy:1.11
           command: ["/cloud_sql_proxy",
                     "-instances=<INSTANCE_CONNECTION_NAME>=tcp:3306",
-                    "-credential_file=/secrets/cloudsql/keys.json"]
+                    "-credential_file=/secrets/cloudsql/key.json"]
           # [START cloudsql_security_context]
           securityContext:
             runAsUser: 2  # non-root user


### PR DESCRIPTION
Fixes to include resolve SQL Proxy failure to find credential file ( named keys.json incorrectly in manifest, changed to key.jso to match secret command in guide)