### PR TITLE
Update query-custom-favicon-metric.py

### DIFF
--- a/16_Logging/query-custom-favicon-metric.py
+++ b/16_Logging/query-custom-favicon-metric.py
@@ -75,4 +75,4 @@ def project_id():
 if __name__ == '__main__':
     result=list_time_series(project_id())
     if result>1:
-        print ("Favicon count: "+result)
+        print ("Favicon count: "+str(result)


### PR DESCRIPTION
Error in return string - can't cast long type to string automatically