### PR TITLE
Updated yaml files for new labs

### DIFF
--- a/16_Monitoring/gcp-gke-monitor-test.yaml
+++ b/16_Monitoring/gcp-gke-monitor-test.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: gcp-gke-monitor-test
+  name: gcp-gke-monitor-test
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: gcp-gke-monitor-test
+  template:
+    metadata:
+      labels:
+        name: gcp-gke-monitor-test
+    spec:
+      containers:
+      - image: [DOCKER-IMAGE]
+        name: gcp-gke-monitor-test
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        env:
+        - name: POD_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: gcp-gke-monitor-test
+  name: gcp-gke-monitor-test-service
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: gcp-gke-monitor-test
+  type: LoadBalancer

--- a/17_Probes/exec-readiness.yaml
+++ b/17_Probes/exec-readiness.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  labels:
+    test: readiness
+  name: readiness-deployment
+spec:
+  replicas: 3
+  selector:
+    matchlables:
+      app: readiness-test
+  template:
+    meta-data:
+      labels:
+        app: readiness-test
+  containers:
+  - name: readiness
+    image: gcr.io/google-samples/hello-app:1.0
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+    image: k8s.gcr.io/busybox
+    args:
+    - /bin/sh
+    - -c
+    - sleep 60; touch /tmp/healthy; sleep (60 + RANDOM % 120) ; rm -rf /tmp/healthy
+    livenessProbe:
+      exec:
+        command:
+        - cat
+        - /tmp/healthy
+      initialDelaySeconds: 5
+      periodSeconds: 5
+    readinessProbe:
+      exec:
+        command:
+        - cat
+        - /tmp/healthy
+      initialDelaySeconds: 300
+      periodSeconds: 5
+apiVersion: v1
+kind: Service
+metadata:
+  name: readiness-svc
+spec:
+  type: ClusterIP
+  selector:
+    matchlables:
+      app: readiness-test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080


### PR DESCRIPTION
Additional yaml for Stackdriver lab ( replacving ref to Brian Eiler's dfocker image and the addition of a kubernetes readiness probe example for Lab 17